### PR TITLE
Use posix compatible tools

### DIFF
--- a/scripts/local-shell.sh
+++ b/scripts/local-shell.sh
@@ -2,8 +2,7 @@
 set -e
 set -x
 
-SCRIPT="$(readlink --canonicalize-existing "$0")"
-SCRIPTPATH="$(dirname "$SCRIPT")"
+SCRIPTPATH="$(cd "$(dirname "$0")" && pwd)"
 source $SCRIPTPATH/local-source.sh
 NIX_SHELL_DRV=$SCRIPTPATH/../
 NIX_SHELL_DRVATTR=shell_${1:-base}


### PR DESCRIPTION
Get `SCRIPTPATH` with posix compatible tools.
This enables usage in BSD based systemes like OS X and in `busybox` environments.

```
⇒  scripts/local-shell.sh
+++ dirname scripts/local-shell.sh
++ cd scripts
++ pwd
+ SCRIPTPATH=/path/to/nix-expressions/scripts
```