### PR TITLE
shells/bsys,syso*: disable hardening for gcc wrappers

### DIFF
--- a/shells/default.nix
+++ b/shells/default.nix
@@ -69,6 +69,9 @@ let
     base = ''
         export PAGER=${pkgs.less}/bin/less
     '';
+    code = ''
+        export hardeningDisable=all
+    '';
     rust = ''
       export RUST_SRC_PATH="${pkgs.rustStable.rustc.src}/src"
     '';
@@ -95,6 +98,7 @@ in {
     ;
     shellHook = with shellHooks;
       base
+      + code
       + rust
     ;
   };
@@ -115,6 +119,7 @@ in {
     ;
     shellHook = with shellHooks;
       base
+      + code
       + rust
     ;
   };
@@ -145,9 +150,8 @@ in {
       ])
     ;
     shellHook = with shellHooks;
-    ''
-        export hardeningDisable=all
-    ''
+        base
+        + code
     ;
   };
 
@@ -166,9 +170,8 @@ in {
       ])
     ;
     shellHook = with shellHooks;
-    ''
-        export hardeningDisable=all
-    ''
+        base
+        + code
     ;
   };
 


### PR DESCRIPTION
Fixes #46.
Fixes #47.