### PR TITLE
shells/base: set GIT_SSH to krb supported ssh path

### DIFF
--- a/shells/default.nix
+++ b/shells/default.nix
@@ -8,7 +8,7 @@ let
   dependencies = {
     base =
       with pkgs; [
-        openssh
+        openssh_with_kerberos
         strace
         file
         man
@@ -72,6 +72,7 @@ let
     base = ''
         export PAGER=${pkgs.less}/bin/less
         source ${pkgs.bash-completion}/etc/profile.d/bash_completion.sh
+        export GIT_SSH=${pkgs.openssh_with_kerberos}/bin/ssh
         '' +
         # FIXME: whys is this needed?
         ''


### PR DESCRIPTION
This is a workaround for `git`. Other tools might still use a different `ssh` version if they depend on the `openssh` package internally.

Closes #55.
Fixes #37.