### PR TITLE
shells: add sysoHW5; mark sysoHW{4,5} unstable;

### DIFF
--- a/shells/default.nix
+++ b/shells/default.nix
@@ -541,7 +541,10 @@ let
   }; # shellDerivations }
 
 in shellDerivations // {
-  sysoHW4 = shellDerivations.sysoHW3.override {
+  sysoHW4 = { unstable = true; } // shellDerivations.sysoHW3.override {
     flavor = "sysoHW4";
+  };
+  sysoHW5 = { unstable = true; } // shellDerivations.sysoHW3.override {
+    flavor = "sysoHW5";
   };
 }


### PR DESCRIPTION
Mark these as unstable so that the CI doesn't run tests.
The tests can safely be skipped since they're only copies of sysoHW3,
which is not marked as unstable and therefore tested by the CI.