### PR TITLE
shells/sysoHW4: fix typo in name

### DIFF
--- a/shells/default.nix
+++ b/shells/default.nix
@@ -487,7 +487,7 @@ let
   };
 
   sysoHW4 = { unstable = true; } // shellDerivations.sysoHW3.override {
-    flavor = "sysoHW5";
+    flavor = "sysoHW4";
   };
 
   sysoHW5 = { unstable = true; } // shellDerivations.sysoHW3.override {


### PR DESCRIPTION
This is a cosmetic change.

Fixes https://github.com/htwg-syslab-syso/syso-ws17-homework/issues/13.